### PR TITLE
Add support for write buffer manager

### DIFF
--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -32,6 +32,8 @@ fn rocksdb_include_dir() -> String {
 fn bindgen_rocksdb() {
     let bindings = bindgen::Builder::default()
         .header(rocksdb_include_dir() + "/rocksdb/c.h")
+        // We add some additional extensions to the rocksdb c-api, until they are merged upstream.
+        .header("c_api_extensions/c.h")
         .derive_debug(false)
         .blocklist_type("max_align_t") // https://github.com/rust-lang-nursery/rust-bindgen/issues/550
         .ctypes_prefix("libc")
@@ -52,6 +54,7 @@ fn build_rocksdb() {
     config.include("rocksdb/include/");
     config.include("rocksdb/");
     config.include("rocksdb/third-party/gtest-1.8.1/fused-src/");
+    config.include("c_api_extensions/");
 
     if cfg!(feature = "snappy") {
         config.define("SNAPPY", Some("1"));
@@ -249,7 +252,7 @@ fn build_rocksdb() {
     for file in lib_sources {
         config.file(format!("rocksdb/{file}"));
     }
-
+    config.file("c_api_extensions/write_buffer_manager.cc");
     config.file("build_version.cc");
 
     config.cpp(true);

--- a/librocksdb-sys/c_api_extensions/c.h
+++ b/librocksdb-sys/c_api_extensions/c.h
@@ -1,0 +1,32 @@
+// These functions are missing from upstream rocksdb/c.h, and will be upstreamed.
+#pragma once
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct rocksdb_options_t rocksdb_options_t;
+/* write_buffer_manager */
+typedef struct rocksdb_write_buffer_manager_t rocksdb_write_buffer_manager_t;
+/* cache */
+typedef struct rocksdb_cache_t rocksdb_cache_t;
+
+void rocksdb_options_set_write_buffer_manager(rocksdb_options_t *opt, rocksdb_write_buffer_manager_t *manager);
+
+/* write_buffer_manager */
+rocksdb_write_buffer_manager_t *rocksdb_write_buffer_manager_create(size_t buffer_size, bool allow_stall);
+rocksdb_write_buffer_manager_t *rocksdb_write_buffer_manager_create_with_cache(size_t buffer_size, rocksdb_cache_t *cache, bool allow_stall);
+
+void rocksdb_write_buffer_manager_destroy(rocksdb_write_buffer_manager_t *manager);
+
+unsigned char rocksdb_write_buffer_manager_enabled(rocksdb_write_buffer_manager_t *manager);
+size_t rocksdb_write_buffer_manager_memory_usage(rocksdb_write_buffer_manager_t *manager);
+size_t rocksdb_write_buffer_manager_buffer_size(rocksdb_write_buffer_manager_t *manager);
+
+#ifdef __cplusplus
+}
+#endif

--- a/librocksdb-sys/c_api_extensions/ctypes.hpp
+++ b/librocksdb-sys/c_api_extensions/ctypes.hpp
@@ -1,0 +1,34 @@
+// Additional cpp types used in `c.h`.
+#pragma once
+
+#include <iostream>
+
+#include "rocksdb/options.h"
+#include "rocksdb/write_buffer_manager.h"
+#include "rocksdb/cache.h"
+
+using std::shared_ptr;
+
+using namespace ROCKSDB_NAMESPACE;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+
+struct rocksdb_options_t {
+  Options rep;
+};
+struct rocksdb_cache_t {
+  std::shared_ptr<Cache> rep;
+};
+/* write_buffer_manager */
+struct rocksdb_write_buffer_manager_t {
+  std::shared_ptr<WriteBufferManager> rep;
+};
+
+#ifdef __cplusplus
+}
+#endif

--- a/librocksdb-sys/c_api_extensions/write_buffer_manager.cc
+++ b/librocksdb-sys/c_api_extensions/write_buffer_manager.cc
@@ -1,0 +1,37 @@
+// Implementation of `WriteBufferManager` types in `c.h`.
+#include "c_api_extensions/ctypes.hpp"
+
+using namespace ROCKSDB_NAMESPACE;
+
+using std::shared_ptr;
+
+extern "C" {
+void rocksdb_options_set_write_buffer_manager(rocksdb_options_t* opt, rocksdb_write_buffer_manager_t* manager) {
+  opt->rep.write_buffer_manager = manager->rep;
+}
+rocksdb_write_buffer_manager_t* rocksdb_write_buffer_manager_create(size_t buffer_size, bool allow_stall) {
+  auto manager = new rocksdb_write_buffer_manager_t;
+  manager->rep.reset(new WriteBufferManager(buffer_size, {}, allow_stall));
+  return manager;
+}
+
+rocksdb_write_buffer_manager_t* rocksdb_write_buffer_manager_create_with_cache(size_t buffer_size, rocksdb_cache_t* cache,bool allow_stall){
+  auto manager = new rocksdb_write_buffer_manager_t;
+  manager->rep.reset(new WriteBufferManager(buffer_size, cache->rep, allow_stall));
+  return manager;
+}
+
+void rocksdb_write_buffer_manager_destroy(rocksdb_write_buffer_manager_t* manager) { delete manager; }
+
+unsigned char rocksdb_write_buffer_manager_enabled(rocksdb_write_buffer_manager_t* manager) {
+  return manager->rep->enabled();
+}
+
+size_t rocksdb_write_buffer_manager_memory_usage(rocksdb_write_buffer_manager_t* manager) {
+  return manager->rep->memory_usage();
+}
+
+size_t rocksdb_write_buffer_manager_buffer_size(rocksdb_write_buffer_manager_t* manager) {
+  return manager->rep->buffer_size();
+}
+}

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -32,7 +32,7 @@ use crate::{
         self, full_merge_callback, partial_merge_callback, MergeFn, MergeOperatorCallback,
     },
     slice_transform::SliceTransform,
-    ColumnFamilyDescriptor, Error, SnapshotWithThreadMode,
+    ColumnFamilyDescriptor, Error, SnapshotWithThreadMode, WriteBufferManager,
 };
 
 pub(crate) struct CacheWrapper {
@@ -3072,6 +3072,29 @@ impl Options {
     pub fn set_allow_ingest_behind(&mut self, val: bool) {
         unsafe {
             ffi::rocksdb_options_set_allow_ingest_behind(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// The memory usage of memtables will report to this `WriteBufferManager`. The same
+    /// `WriteBufferManager` can be  can be passed into multiple DBs and it will track the
+    /// sum of size of all the DBs. If the total size of all live memtables of all the
+    /// DBs exceeds a limit, a flush will be triggered in the next DB to which the next write
+    /// is issued, as long as there is one or more column family not already
+    /// flushing.
+    ///
+    /// If the object is only passed to one DB, the behavior is the same as
+    /// `db_write_buffer_size`. When `set_write_buffer_manager` is called, the value set will
+    /// override the call to `set_db_write_buffer_size`.
+    ///
+    /// This feature is disabled by default.
+    pub fn set_write_buffer_manager(&mut self, write_buffer_manager: &WriteBufferManager) {
+        // Safety: `WriteBufferManager` is guaranteed to point to a `shared_ptr` to the
+        // underlying cpp `WriteBufferManager`.
+        unsafe {
+            ffi::rocksdb_options_set_write_buffer_manager(
+                self.inner,
+                write_buffer_manager.0.inner.as_ptr(),
+            );
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,7 @@ mod snapshot;
 mod sst_file_writer;
 mod transactions;
 mod write_batch;
+mod write_buffer_manager;
 
 pub use crate::{
     column_family::{
@@ -132,6 +133,7 @@ pub use crate::{
         TransactionDBOptions, TransactionOptions,
     },
     write_batch::{WriteBatch, WriteBatchIterator, WriteBatchWithTransaction},
+    write_buffer_manager::WriteBufferManager,
 };
 
 use librocksdb_sys as ffi;
@@ -227,7 +229,7 @@ impl fmt::Display for Error {
 mod test {
     use crate::{
         OptimisticTransactionDB, OptimisticTransactionOptions, Transaction, TransactionDB,
-        TransactionDBOptions, TransactionOptions,
+        TransactionDBOptions, TransactionOptions, WriteBufferManager,
     };
 
     use super::{
@@ -274,6 +276,7 @@ mod test {
         is_send::<TransactionDBOptions>();
         is_send::<OptimisticTransactionOptions>();
         is_send::<TransactionOptions>();
+        is_send::<WriteBufferManager>();
     }
 
     #[test]
@@ -304,5 +307,6 @@ mod test {
         is_sync::<TransactionDBOptions>();
         is_sync::<OptimisticTransactionOptions>();
         is_sync::<TransactionOptions>();
+        is_sync::<WriteBufferManager>();
     }
 }

--- a/src/write_buffer_manager.rs
+++ b/src/write_buffer_manager.rs
@@ -1,0 +1,213 @@
+//! `WriteBufferManager` is for managing memory allocation for one or more
+//! MemTables.
+use std::ptr::NonNull;
+use std::sync::Arc;
+
+use crate::{ffi, Cache};
+
+pub(crate) struct WriteBufferManagerWrapper {
+    pub(crate) inner: NonNull<ffi::rocksdb_write_buffer_manager_t>,
+}
+
+// Just like the types in the `db_options` module, these are only safe because
+// the underlying types are thread-safe. This thread-safety is not actually
+// documented, but an evaluation of the code revealed that all member
+// variables are protected by mutexes or atomics. Also, sharing `WriteBufferManager`'s
+// across threads is the intended usecase for the underlying cpp type.
+unsafe impl Send for WriteBufferManagerWrapper {}
+unsafe impl Sync for WriteBufferManagerWrapper {}
+
+impl Drop for WriteBufferManagerWrapper {
+    // Safety: `inner` is guaranteed to point to a `shared_ptr` to the
+    // underlying cpp `WriteBufferManager`.
+    fn drop(&mut self) {
+        unsafe {
+            ffi::rocksdb_write_buffer_manager_destroy(self.inner.as_ptr());
+        }
+    }
+}
+
+/// A `WriteBufferManager`, which can be `Cloned` and shared across RocksDB instances to control
+/// global memory usage. See
+/// <https://github.com/facebook/rocksdb/wiki/Write-Buffer-Manager>
+/// for more information.
+// Note that we _could_ clone the underlying `std::shared_ptr`, but just storing
+// it in an `Arc`, with the underlying calls (like `rocksdb_options_set_write_buffer_manager`)
+// copy-construct the underlying `std::shared_ptr` is much easier, and is the same way
+// we do it for types like `db_options::Cache`.
+#[derive(Clone)]
+pub struct WriteBufferManager(pub(crate) Arc<WriteBufferManagerWrapper>);
+
+impl WriteBufferManager {
+    /// Creates a new `WriteBufferManager` with a set `buffer_size`.
+    ///
+    /// buffer_size = 0 indicates no limit.
+    pub fn new(buffer_size: usize) -> WriteBufferManager {
+        Self::new_with_allow_stall(buffer_size, false)
+    }
+
+    /// Creates a new `WriteBufferManager` with a set `buffer_size`, and an `allow_stall`
+    /// configuration.
+    ///
+    /// allow_stall: if set true, it will enable stalling of writes when
+    /// memory_usage() exceeds buffer_size. It will wait for flush to complete and
+    /// memory usage to drop down.
+    ///
+    /// buffer_size = 0 indicates no limit.
+    pub fn new_with_allow_stall(buffer_size: usize, allow_stall: bool) -> WriteBufferManager {
+        WriteBufferManager(Arc::new(WriteBufferManagerWrapper {
+            // Safety: `rocksdb_write_buffer_manager_create` is guaranteed to create a non-null and valid
+            // pointer to the underlying cpp type.
+            inner: NonNull::new(unsafe {
+                ffi::rocksdb_write_buffer_manager_create(buffer_size, allow_stall)
+            })
+            .unwrap(),
+        }))
+    }
+
+    /// Creates a new `WriteBufferManager` with a `Cache`.
+    ///
+    /// buffer_size: buffer_size = 0 indicates no limit.
+    /// cache: RocksDB will put dummy entries in the cache and
+    /// cost the memory allocated to the cache. It can be used even if _buffer_size
+    /// = 0. Note that `Cache` can also be shared across RocksDB instances.
+    /// See
+    /// <https://github.com/facebook/rocksdb/wiki/Write-Buffer-Manager#cost-memory-used-in-memtable-to-block-cache>
+    /// for more information.
+    ///
+    /// allow_stall: if set true, it will enable stalling of writes when
+    /// memory_usage() exceeds buffer_size. It will wait for flush to complete and
+    /// memory usage to drop down.
+    pub fn new_with_cache(
+        buffer_size: usize,
+        cache: &Cache,
+        allow_stall: bool,
+    ) -> WriteBufferManager {
+        WriteBufferManager(Arc::new(WriteBufferManagerWrapper {
+            // Safety: `rocksdb_write_buffer_manager_create` is guaranteed to create a non-null and valid
+            // pointer to the underlying cpp type.
+            inner: NonNull::new(unsafe {
+                ffi::rocksdb_write_buffer_manager_create_with_cache(
+                    buffer_size,
+                    cache.0.inner.as_ptr(),
+                    allow_stall,
+                )
+            })
+            .unwrap(),
+        }))
+    }
+
+    /// Returns true if buffer_limit is passed to limit the total memory usage and
+    /// is greater than 0.
+    pub fn enabled(&self) -> bool {
+        // Safety: `inner` is guaranteed to point to a `shared_ptr` to the
+        // underlying cpp `WriteBufferManager`.
+        unsafe { ffi::rocksdb_write_buffer_manager_enabled(self.0.inner.as_ptr()) != 0 }
+    }
+
+    /// Returns the total memory used by memtables if enabled.
+    pub fn memory_usage(&self) -> Option<usize> {
+        if self.enabled() {
+            // Safety: `inner` is guaranteed to point to a `shared_ptr` to the
+            // underlying cpp `WriteBufferManager`.
+            Some(unsafe { ffi::rocksdb_write_buffer_manager_memory_usage(self.0.inner.as_ptr()) })
+        } else {
+            None
+        }
+    }
+
+    /// Returns the buffer_size.
+    pub fn buffer_size(&self) -> usize {
+        // Safety: `inner` is guaranteed to point to a `shared_ptr` to the
+        // underlying cpp `WriteBufferManager`.
+        unsafe { ffi::rocksdb_write_buffer_manager_buffer_size(self.0.inner.as_ptr()) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Options, DB};
+    use std::iter;
+    use tempfile::TempDir;
+
+    #[test]
+    fn write_buffer_manager_of_2db() {
+        let tmp_dir1 = TempDir::new().unwrap();
+        let tmp_dir2 = TempDir::new().unwrap();
+        let cache = Cache::new_lru_cache(10240);
+        let manager = WriteBufferManager::new_with_cache(102400, &cache, false);
+        let mut op1 = Options::default();
+        op1.create_if_missing(true);
+        op1.set_write_buffer_manager(&manager);
+        let mut op2 = Options::default();
+        op2.create_if_missing(true);
+        op2.set_write_buffer_manager(&manager);
+        assert_eq!(manager.memory_usage(), Some(0));
+        let db1 = DB::open(&op1, &tmp_dir1).unwrap();
+
+        let mem1 = manager.memory_usage().unwrap();
+
+        let db2 = DB::open(&op2, &tmp_dir2).unwrap();
+
+        assert_eq!(manager.enabled(), true);
+        let mem2 = manager.memory_usage().unwrap();
+        assert!(mem2 > mem1);
+
+        for i in 0..100 {
+            let key = format!("k{}", i);
+            let val = format!("v{}", i * i);
+            let value: String = iter::repeat(val).take(i * i).collect::<Vec<_>>().concat();
+
+            db1.put(key.as_bytes(), value.as_bytes()).unwrap();
+        }
+
+        let mem3 = manager.memory_usage().unwrap();
+        assert!(mem3 > mem2);
+
+        for i in 0..100 {
+            let key = format!("k{}", i);
+            let val = format!("v{}", i * i);
+            let value: String = iter::repeat(val).take(i * i).collect::<Vec<_>>().concat();
+
+            db2.put(key.as_bytes(), value.as_bytes()).unwrap();
+        }
+
+        let mem4 = manager.memory_usage().unwrap();
+        assert!(mem4 > mem3);
+
+        assert!(db2.flush().is_ok());
+        let mem5 = manager.memory_usage().unwrap();
+        assert!(mem5 < mem4);
+
+        drop(db1);
+        drop(db2);
+        assert_eq!(manager.memory_usage(), Some(0));
+    }
+
+    #[test]
+    fn write_buffer_manager_plain_new() {
+        let tmp_dir1 = TempDir::new().unwrap();
+        let manager = WriteBufferManager::new(102400);
+        let mut op1 = Options::default();
+        op1.create_if_missing(true);
+        op1.set_write_buffer_manager(&manager);
+
+        assert_eq!(manager.memory_usage(), Some(0));
+        let db1 = DB::open(&op1, &tmp_dir1).unwrap();
+
+        assert_eq!(manager.enabled(), true);
+        assert!(manager.memory_usage().unwrap() > 0);
+
+        for i in 0..100 {
+            let key = format!("k{}", i);
+            let val = format!("v{}", i * i);
+            let value: String = iter::repeat(val).take(i * i).collect::<Vec<_>>().concat();
+
+            db1.put(key.as_bytes(), value.as_bytes()).unwrap();
+        }
+
+        drop(db1);
+        assert_eq!(manager.memory_usage(), Some(0));
+    }
+}


### PR DESCRIPTION
This is a change adapted from @sjwiesman 's work here: https://github.com/sjwiesman/rust-rocksdb/pull/1/files

It effectively extends the c-api of `rocksdb` to expose the `WriteBufferManager` (which can control global memory usage), in the same way as other types like `Cache` are exposed by the current c api. These extensions will be upstreamed here: https://github.com/facebook/rocksdb/pull/11710, but I don't want to block on that.

I adjusted some naming and cleaned up some of the rust binding code. Also ensured that the exposed `WriteBufferManager` is `Clone`, which is required to actually share the manager across instances of rocksdb

Note also that this is a branch on `master`, which will bump the built version of rocksdb we use in mz from 8.1 to 8.3