### PR TITLE
build: Specify target_cpu when building rocksdb

### DIFF
--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -41,3 +41,4 @@ cc = { version = "1.0", features = ["parallel"] }
 bindgen = { version = "0.65", default-features = false, features = ["runtime"] }
 glob = "0.3"
 pkg-config = { version = "0.3", optional = true }
+rustflags = "0.1.4"


### PR DESCRIPTION
Related to: https://github.com/MaterializeInc/materialize/pull/22187

This PR updates to build script for `librocksdb-sys` to try reading the `target_cpu` from the environment variables and set the corresponding `-march` and `-mtune` flags. This should enable us to leverage more modern SIMD instructions in RocksDB.

To validate that this change works I built `librocksdb-sys` then decompiled the resulting binary and [checked the count of various SIMD classes](https://stackoverflow.com/questions/47878352/how-to-check-if-compiled-code-uses-sse-and-avx-instructions).

class |branch   |main
------|---------|----
sse2  | 0       | 22,070
sse3  | 0       | 0
ssse3 | 0       | 0
sse4  | 97      | 0
avx   | 26,056  | 0

So specifying the `target_cpu`, in this case `x86-64-v3` resulted in a binary that uses almost exclusively AVX instructions, as opposed to the current build from `main` which only used SSE2.

#### Benchmarks

No idea how to benchmark this, if anyone has suggestions I would be more than happy to run them!